### PR TITLE
Change approach to be able to reset validations for successful images

### DIFF
--- a/dist/ng-file-upload-all.js
+++ b/dist/ng-file-upload-all.js
@@ -2412,7 +2412,7 @@ define(['angular'], function (angular) {
           } catch (e) {/* Fix IE11 that throw error calling getData */
           }
           extractFiles(source.items, source.files, attrGetter('ngfAllowDir', scope) !== false,
-            attrGetter('multiple') || attrGetter('ngfMultiple', scope), attrGetter('ngfValidateMultiple')).then(function (files) {
+            attrGetter('multiple') || attrGetter('ngfMultiple', scope)).then(function (files) {
             if (files.length) {
               updateModel(files, evt);
             } else {
@@ -2478,7 +2478,7 @@ define(['angular'], function (angular) {
           callback(dClass);
         }
 
-        function extractFiles(items, fileList, allowDir, multiple, validateMultiple) {
+        function extractFiles(items, fileList, allowDir, multiple) {
           var maxFiles = upload.getValidationAttr(attr, scope, 'maxFiles');
           if (maxFiles == null) {
             maxFiles = Number.MAX_VALUE;
@@ -2569,12 +2569,9 @@ define(['angular'], function (angular) {
                 }
               }
 
-              if (files.length > maxFiles || (!multiple && files.length > 0)) {
-                // Model validity is set here because the additional files are dropped and not sent to the model.
-                if (validateMultiple) {
-                  ngModel.$setValidity('tooManyFiles', false);
-                }
-
+              if (files.length > maxFiles || (!multiple && files.length > 1)) {
+                // Setting a model property, that way the validation happens in the right place.
+                files[0].$maxFilesInvalid = true;
                 break;
               }
 
@@ -2591,12 +2588,9 @@ define(['angular'], function (angular) {
                   totalSize += file.size;
                 }
 
-                if (files.length > maxFiles || (!multiple && files.length > 0)) {
-                  // Model validity is set here because the additional files are dropped and not sent to the model.
-                  if (validateMultiple) {
-                    ngModel.$setValidity('tooManyFiles', false);
-                  }
-                  
+                if (files.length > maxFiles || (!multiple && files.length > 1)) {
+                  // Setting a model property, that way the validation happens in the right place.
+                  files[0].$maxFilesInvalid = true;
                   break;
                 }
 

--- a/src/drop.js
+++ b/src/drop.js
@@ -137,7 +137,7 @@
       } catch (e) {/* Fix IE11 that throw error calling getData */
       }
       extractFiles(source.items, source.files, attrGetter('ngfAllowDir', scope) !== false,
-        attrGetter('multiple') || attrGetter('ngfMultiple', scope), attrGetter('ngfValidateMultiple')).then(function (files) {
+        attrGetter('multiple') || attrGetter('ngfMultiple', scope)).then(function (files) {
         if (files.length) {
           updateModel(files, evt);
         } else {
@@ -203,7 +203,7 @@
       callback(dClass);
     }
 
-    function extractFiles(items, fileList, allowDir, multiple, validateMultiple) {
+    function extractFiles(items, fileList, allowDir, multiple) {
       var maxFiles = upload.getValidationAttr(attr, scope, 'maxFiles');
       if (maxFiles == null) {
         maxFiles = Number.MAX_VALUE;
@@ -294,12 +294,8 @@
             }
           }
 
-          if (files.length > maxFiles || (!multiple && files.length > 0)) {
-            // Model validity is set here because the additional files are dropped and not sent to the model.
-            if (validateMultiple) {
-              ngModel.$setValidity('tooManyFiles', false);
-            }
-
+          if (files.length > maxFiles || (!multiple && files.length > 1)) {
+            files[0].$maxFilesInvalid = true;
             break;
           }
 
@@ -316,12 +312,8 @@
               totalSize += file.size;
             }
 
-            if (files.length > maxFiles || (!multiple && files.length > 0)) {
-              // Model validity is set here because the additional files are dropped and not sent to the model.
-              if (validateMultiple) {
-                ngModel.$setValidity('tooManyFiles', false);
-              }
-              
+            if (files.length > maxFiles || (!multiple && files.length > 1)) {
+              files[0].$maxFilesInvalid = true;
               break;
             }
 

--- a/src/upload.js
+++ b/src/upload.js
@@ -1,5 +1,5 @@
 /**!
- * AngularJS file upload directives and services. Supoorts: file upload/drop/paste, resume, cancel/abort,
+ * AngularJS file upload directives and services. Supports: file upload/drop/paste, resume, cancel/abort,
  * progress, resize, thumbnail, preview, validation and CORS
  * @author  Danial  <danial.farid@gmail.com>
  * @version <%= pkg.version %>


### PR DESCRIPTION
#2 had a bug, once `ngModel.$setValidity('tooManyFiles', false)` was executed it couldn't be reset, hence the form was always invalid. Furthermore, the validity needed to be reset from other sources, e.g. select. I decided to change the approach and set a property of the model, which gets picked up by the validator instead. A little hacky but way more flexible and fixes the bug.